### PR TITLE
chore: Fixed Docker Hub repo name

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -48,7 +48,7 @@ jobs:
             latest=false
           images: |
             ghcr.io/${{ github.repository }}
-            docker.io/${{ github.repository }}
+            docker.io/${{ secrets.DOCKERHUB_REPO }}
           tags: |
             type=raw,value=${{ matrix.os }}-main
             type=raw,value=main,enable=${{ matrix.os == 'alpine' }}
@@ -141,4 +141,4 @@ jobs:
         run: |
           set -euo pipefail
           cosign sign --yes --recursive ghcr.io/${{ github.repository }}:main@${{ steps.build_push.outputs.digest }}
-          cosign sign --yes --recursive docker.io/${{ github.repository }}:main@${{ steps.build_push.outputs.digest }}
+          cosign sign --yes --recursive docker.io/${{ secrets.DOCKERHUB_REPO }}:main@${{ steps.build_push.outputs.digest }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
             latest=false
           images: |
             ghcr.io/${{ github.repository }}
-            docker.io/${{ github.repository }}
+            docker.io/${{ secrets.DOCKERHUB_REPO }}
           tags: |
             type=semver,pattern=${{ matrix.os }}-{{version}}
             type=semver,pattern=${{ matrix.os }}-{{major}}.{{minor}}
@@ -146,7 +146,7 @@ jobs:
         run: |
           set -euo pipefail
           cosign sign --yes --recursive ghcr.io/${{ github.repository }}:${{ steps.metadata.outputs.version }}@${{ steps.build_push.outputs.digest }}
-          cosign sign --yes --recursive docker.io/${{ github.repository }}:${{ steps.metadata.outputs.version }}@${{ steps.build_push.outputs.digest }}
+          cosign sign --yes --recursive docker.io/${{ secrets.DOCKERHUB_REPO }}:${{ steps.metadata.outputs.version }}@${{ steps.build_push.outputs.digest }}
 
       - name: Update Docker repository description
         uses: peter-evans/dockerhub-description@14881160433a81f9ebc838a253d4edd9e8fc35f1


### PR DESCRIPTION
@patrick-stephens I missed this change as my GH repo is named the same as the image. Before this is merged we need the `DOCKERHUB_REPO`, `DOCKERHUB_USERNAME` & `DOCKERHUB_TOKEN` repo secrets added for the GH Actions on the `main` branch and when we release a tag.