### PR TITLE
chore: Updated CHANGELOG for v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecated
 - Removed -->
 
-## [v1.0.0] - UNRELEASED
+## [v1.0.0] - 2022-11-21
 
 ### All Changes
 


### PR DESCRIPTION
@patrick-stephens we can add a bit more to the CHANGELOG if you like? Once this is merged the `v1.0.0` tag needs to be added to create the release.