### PR TITLE
chore: Fixed release SBOM generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Generate OCI image SBOM
         uses: anchore/sbom-action@06e109483e6aa305a2b2395eabae554e51530e1d
         with:
-          image: "ghcr.io/${{ github.repository }}:${{ matrix.os }}-${{ steps.metadata.outputs.version }}"
+          image: "ghcr.io/${{ github.repository }}:${{ steps.metadata.outputs.version }}"
           dependency-snapshot: true
           format: spdx-json
           artifact-name: ${{ github.event.repository.name }}-sbom.spdx.json


### PR DESCRIPTION
@patrick-stephens could you delete the `v1.0.0` tag and merge this so I can re-run the release?