### PR TITLE
chore: Fixed release GH Action order

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -147,6 +147,7 @@ jobs:
 
   publish:
     name: Publish Release
+    needs: release
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
This PR makes the release publish job wait for the artefacts to have been created before running.